### PR TITLE
Update widgets.py : _rendercursor of TextBox class can be used also with different locations of text_disp

### DIFF
--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -994,7 +994,7 @@ class TextBox(AxesWidget):
         lambda self: self._observers.callbacks['submit']))
 
     def __init__(self, ax, label, initial='',
-                 color='.95', hovercolor='1', label_pad=.01):
+                 color='.95', hovercolor='1', label_pad=.01, ha = "left"):
         """
         Parameters
         ----------
@@ -1010,17 +1010,19 @@ class TextBox(AxesWidget):
             The color of the box when the mouse is over it.
         label_pad : float
             The distance between the label and the right side of the textbox.
+        ha :
+            The horizontal location of the text
         """
         super().__init__(ax)
 
-        self.DIST_FROM_LEFT = .05
-
+        ha_dist = {"left": 0.05, "center":0.5, "right":0.95}
+        self.DIST = ha_dist[ha]
         self.label = ax.text(
             -label_pad, 0.5, label, transform=ax.transAxes,
             verticalalignment='center', horizontalalignment='right')
         self.text_disp = self.ax.text(
-            self.DIST_FROM_LEFT, 0.5, initial, transform=self.ax.transAxes,
-            verticalalignment='center', horizontalalignment='left')
+            self.DIST, 0.5, initial, transform=self.ax.transAxes,
+            verticalalignment='center', horizontalalignment=ha)
 
         self._observers = cbook.CallbackRegistry()
 
@@ -1063,15 +1065,26 @@ class TextBox(AxesWidget):
 
         text = self.text_disp.get_text()  # Save value before overwriting it.
         widthtext = text[:self.cursor_index]
+
+        bb_1 = self.text_disp.get_window_extent()
+
         self.text_disp.set_text(widthtext or ",")
-        bb = self.text_disp.get_window_extent()
-        if not widthtext:  # Use the comma for the height, but keep width to 0.
-            bb.x1 = bb.x0
+        
+        bb_2 = self.text_disp.get_window_extent()
+
+        if bb_1.y0 == bb_1.y1 : #no text
+            bb_1.y0 -= (bb_2.y1-bb_2.y0)/2
+            bb_1.y1 += (bb_2.y1-bb_2.y0)/2
+        elif not widthtext: #cursor at index 0
+            bb_1.x1 = bb_1.x0
+        else :
+            bb_1.x1 = bb_1.x0 + (bb_2.x1 - bb_2.x0)
+            
         self.cursor.set(
-            segments=[[(bb.x1, bb.y0), (bb.x1, bb.y1)]], visible=True)
+            segments=[[(bb_1.x1, bb_1.y0), (bb_1.x1, bb_1.y1)]], visible=True)
         self.text_disp.set_text(text)
 
-        self.ax.figure.canvas.draw()
+        self.ax.figure.canvas.draw() 
 
     def _release(self, event):
         if self.ignore(event):


### PR DESCRIPTION
## PR Summary

I updated the _rendercursor function of the TextBox class so that now it is possible to locate the text in other positions e.g. the center of the TextBox, with the cursor following it. Previously the cursor would have cut a letter if just the property of self.text_disp in __init__ had been changed.
## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [N/A] Has pytest style unit tests (and `pytest` passes).
- [N/A]  Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [N/A] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
